### PR TITLE
Fix return of nonzero exit codes on unix.

### DIFF
--- a/pidlock.py
+++ b/pidlock.py
@@ -109,7 +109,12 @@ def pidlock_cli():
         with locker.lock(parsed.name):
             if parsed.verbose:
                 print("Running command:", parsed.command)
-            quit(os.system(parsed.command))
+            rval = os.system(parsed.command)
+            if os.name in ['posix']:
+                # On unix this is a two byte number who's higher byte contains the processes exit code.
+                # https://docs.python.org/2/library/os.html#os.system
+                rval = rval >> 8
+            quit(rval)
     except PIDLockedException as e:
         print('pidlock:', e, file=sys.stderr)
         quit(1)

--- a/pidlock.py
+++ b/pidlock.py
@@ -8,6 +8,7 @@ Documentation:  https://github.com/sayanarijit/pidlock
 from __future__ import print_function
 import os
 import sys
+import subprocess
 import psutil
 from os import path
 from codecs import open
@@ -109,12 +110,7 @@ def pidlock_cli():
         with locker.lock(parsed.name):
             if parsed.verbose:
                 print("Running command:", parsed.command)
-            rval = os.system(parsed.command)
-            if os.name in ['posix']:
-                # On unix this is a two byte number who's higher byte contains the processes exit code.
-                # https://docs.python.org/2/library/os.html#os.system
-                rval = rval >> 8
-            quit(rval)
+            quit(subprocess.Popen(parsed.command, shell=True).wait())
     except PIDLockedException as e:
         print('pidlock:', e, file=sys.stderr)
         quit(1)


### PR DESCRIPTION
On some (all?) linux systems nonzero exit codes where not propagated successfully. I believe this is due to a misunderstanding of the return value of `os.system` and that the original author intended nonzero exit codes to be propagated to the calling process. `os.system` actually returns a two byte value the higher byte represents the return value and the lower a signal.

Previously it was possible for some failing commands to return an exit code of 0.

Eg 

```
marco@pastel:~$ pidlock -n test -c "false"
marco@pastel:~$ echo $?
0
```

With this PR the return value is nonzero.